### PR TITLE
Fix chmod to only add executable bit

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,16 +3,16 @@
 echo "Downloading web components..."
 git submodule update --init --recursive
 # Build UI components
-chmod 777 buildWeb.sh
+chmod +x buildWeb.sh
 ./buildWeb.sh
 # Init local repo
 rm -rf "local-repo"
 mkdir -p "local-repo"
 # Get android JAR
-chmod 777 getAndroid.sh
+chmod +x getAndroid.sh
 ./getAndroid.sh
 # Get Spark
-chmod 777 getSpark.sh
+chmod +x getSpark.sh
 ./getSpark.sh
 # Remove old build
 rm -rf target


### PR DESCRIPTION
Setting shell scripts to be world writable is a security issue. For example another user could edit the script to execute malicious code and it would automatically just get ran by the build.sh script if you didn't audit it.