### PR TITLE
Remove useless error output

### DIFF
--- a/scripts/getAndroid.sh
+++ b/scripts/getAndroid.sh
@@ -61,7 +61,7 @@ function dedup() {
     do
         NAME="${class%.*}"
         echo "Processing class: $NAME"
-        zip --delete "$ABS_JAR" "$NAME.class" "$NAME\$*.class" "${NAME}Kt.class" "${NAME}Kt\$*.class"
+        zip --delete "$ABS_JAR" "$NAME.class" "$NAME\$*.class" "${NAME}Kt.class" "${NAME}Kt\$*.class" > /dev/null
     done
     popd
 }


### PR DESCRIPTION
redirect "zip warning: name not matched:" messages to /dev/null